### PR TITLE
chore: fix iad() call and track usb-device minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2023-04-14
 Initial release
 
+## [0.1.1] - 2024-02-05
+Restrict `usb-device` dependency to supported versions: < 0.3
+
+## [0.2.0] - 2024-02-05
+Support `usb-device@0.3`
+
 [unreleased]: https://github.com/apohrebniak/usbd-storage/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/apohrebniak/usbd-storage/releases/tag/v0.1.0
+[0.1.1]: https://github.com/apohrebniak/usbd-storage/releases/tag/v0.1.1
+[0.2.0]: https://github.com/apohrebniak/usbd-storage/releases/tag/v0.2.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usbd-storage"
 description = "USB Mass Storage class for usb-device."
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/apohrebniak/usbd-storage"
@@ -11,7 +11,7 @@ homepage = "https://github.com/apohrebniak/usbd-storage"
 
 # USB stack
 [dependencies.usb-device]
-version = "0.2.9"
+version = "0.3"
 
 # Logging
 [dependencies.defmt]
@@ -45,8 +45,8 @@ features = ["critical-section-single-core"]
 # "usb_fs" enables OTG peripheral access
 # https://docs.rs/cortex-m-rt/latest/cortex_m_rt/#device
 [dev-dependencies.stm32f4xx-hal]
-version = "0.15.0"
-features = ["stm32f411", "rt", "usb_fs"]
+version = "0.20.0"
+features = ["stm32f411", "usb_fs"]
 
 # peripheral-access crate
 [dev-dependencies.stm32f4]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "usbd-storage"
 description = "USB Mass Storage class for usb-device."
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/apohrebniak/usbd-storage"
@@ -11,7 +11,7 @@ homepage = "https://github.com/apohrebniak/usbd-storage"
 
 # USB stack
 [dependencies.usb-device]
-version = "0"
+version = "0.2.9"
 
 # Logging
 [dependencies.defmt]

--- a/src/subclass/scsi.rs
+++ b/src/subclass/scsi.rs
@@ -273,6 +273,7 @@ where
             CLASS_MASS_STORAGE,
             SUBCLASS_SCSI,
             T::PROTO,
+            None,
         )?;
         writer.interface(self.interface, CLASS_MASS_STORAGE, SUBCLASS_SCSI, T::PROTO)?;
 


### PR DESCRIPTION
This was changed in rust-embedded-community/usb-device@8d132e134e3c1 (tagged v0.3.0)