### PR TITLE
fix: Cannot faild command

### DIFF
--- a/usbd-storage/Cargo.toml
+++ b/usbd-storage/Cargo.toml
@@ -29,6 +29,10 @@ bbb = []
 ufi = []
 scsi = []
 
+[[test]]
+name = "scsi_bbb"
+required-features = ["scsi", "bbb"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/usbd-storage/tests/common/bbb.rs
+++ b/usbd-storage/tests/common/bbb.rs
@@ -1,0 +1,349 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use usb_device::bus::{PollResult, UsbBus};
+use usb_device::class_prelude::{EndpointAddress, EndpointType};
+use usb_device::{UsbDirection, UsbError};
+
+const MAX_CB_LEN: u8 = 16;
+const CSW_LEN: u8 = 13;
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum CommandStatus {
+    Passed = 0x00,
+    Failed = 0x01,
+    PhaseError = 0x02,
+}
+
+#[allow(dead_code)]
+pub enum DataDirection {
+    Out,
+    In,
+    NotExpected,
+}
+pub struct CBW {
+    pub(crate) data_transfer_len: u32,
+    pub(crate) direction: DataDirection,
+    pub(crate) block: Vec<u8>,
+}
+
+impl CBW {
+    pub fn into_bytes(self) -> Vec<u8> {
+        const CBW_SIGNATURE_LE: [u8; 4] = 0x43425355u32.to_le_bytes();
+
+        assert!((1..=16).contains(&self.block.len()));
+
+        let mut bytes = vec![];
+        bytes.extend_from_slice(CBW_SIGNATURE_LE.as_slice()); // signature
+        bytes.extend_from_slice([0u8; 4].as_slice()); //tag
+        bytes.extend_from_slice(self.data_transfer_len.to_le_bytes().as_slice()); // data transfer len
+
+        let direction = match self.direction {
+            DataDirection::In => 1_u8 << 7,
+            DataDirection::Out | DataDirection::NotExpected => 0u8,
+        };
+        bytes.push(direction); // direction
+        bytes.push(0); // lun
+        bytes.push(self.block.len() as u8); // block size
+
+        let mut block = vec![0u8; MAX_CB_LEN as usize];
+        block.as_mut_slice()[..self.block.len()].copy_from_slice(self.block.as_slice());
+        bytes.extend_from_slice(block.as_slice()); // block
+
+        bytes
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct CSW {
+    pub(crate) data_transfer_len: u32,
+    pub(crate) status: CommandStatus,
+}
+
+impl CSW {
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        assert_eq!(CSW_LEN as usize, bytes.len());
+
+        let data_transfer_len = u32::from_le_bytes(bytes[8..12].try_into().unwrap());
+        let status = match bytes[12] {
+            0x00 => CommandStatus::Passed,
+            0x01 => CommandStatus::Failed,
+            0x02 => CommandStatus::PhaseError,
+            _ => panic!("invalid status code"),
+        };
+
+        Self {
+            data_transfer_len,
+            status,
+        }
+    }
+}
+
+pub struct DummyEp {
+    addr: EndpointAddress,
+    max_packet_size: u16,
+    stalled: bool,
+    bytes_written: usize,
+    bytes_read: usize,
+    packets: VecDeque<Vec<u8>>,
+}
+
+impl DummyEp {
+    pub fn new(addr: EndpointAddress, max_packet_size: u16) -> Self {
+        Self {
+            addr,
+            max_packet_size,
+            stalled: false,
+            bytes_written: 0,
+            bytes_read: 0,
+            packets: VecDeque::new(),
+        }
+    }
+
+    pub fn write_bytes(&mut self, bytes: &[u8]) {
+        for chunk in bytes.chunks(self.max_packet_size as usize) {
+            self.packets.push_back(chunk.to_vec());
+        }
+        self.bytes_written += bytes.len();
+    }
+
+    pub fn read_packet(&mut self) -> Option<Vec<u8>> {
+        let packet = self.packets.pop_front();
+        if let Some(len) = packet.as_ref().map(|p| p.len()) {
+            self.bytes_read += len;
+        }
+        packet
+    }
+}
+
+#[derive(Eq, PartialEq)]
+pub struct BytesProcessed {
+    /// (written, read)
+    ep_in: (usize, usize),
+    /// (written, read)
+    ep_out: (usize, usize),
+}
+
+#[derive(Clone)]
+pub struct DummyUsbBus {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl DummyUsbBus {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Inner::new())),
+        }
+    }
+
+    /// Write Command Block Wrapper as if it was written by a USB host
+    pub fn write_cbw(&self, cbw: CBW) {
+        let mut lock = self.inner.lock().unwrap();
+        let ep = lock.ep_out.as_mut().unwrap();
+        ep.write_bytes(cbw.into_bytes().as_slice());
+    }
+
+    /// Read Command Status as if it was read by a USB host
+    pub fn read_cs(&self) -> Option<CSW> {
+        let mut bytes = vec![];
+        while bytes.len() < CSW_LEN as usize {
+            let mut packet = self.read_packet()?;
+            bytes.append(&mut packet);
+        }
+        Some(CSW::from_bytes(bytes.as_slice()))
+    }
+
+    /// Write some data as if it was written by a USB host during Host to Device data transfer
+    pub fn write_data(&self, data: &[u8]) {
+        let mut lock = self.inner.lock().unwrap();
+        let ep = lock.ep_out.as_mut().unwrap();
+        ep.write_bytes(data);
+    }
+
+    /// Read a single packet as if it was read by a USB host during Device to Host data transfer
+    pub fn read_packet(&self) -> Option<Vec<u8>> {
+        let mut lock = self.inner.lock().unwrap();
+        let ep = lock.ep_in.as_mut().unwrap();
+        ep.read_packet()
+    }
+
+    pub fn read_n_bytes(&self, n: usize) -> Vec<u8> {
+        let mut lock = self.inner.lock().unwrap();
+        let ep = lock.ep_in.as_mut().unwrap();
+
+        assert_eq!(0, n % ep.max_packet_size as usize);
+
+        let mut bytes = vec![];
+        while bytes.len() < n {
+            match ep.read_packet() {
+                None => {
+                    break;
+                }
+                Some(mut packet) => {
+                    bytes.append(&mut packet);
+                }
+            }
+        }
+
+        bytes
+    }
+
+    pub fn bytes_processed(&self) -> BytesProcessed {
+        let lock = self.inner.lock().unwrap();
+        BytesProcessed {
+            ep_in: (lock
+                .ep_in
+                .as_ref()
+                .map(|ep| (ep.bytes_written, ep.bytes_read))
+                .unwrap()),
+            ep_out: (lock
+                .ep_out
+                .as_ref()
+                .map(|ep| (ep.bytes_written, ep.bytes_read))
+                .unwrap()),
+        }
+    }
+}
+
+struct Inner {
+    enabled: bool,
+    ep_in: Option<DummyEp>,
+    ep_out: Option<DummyEp>,
+}
+
+impl Inner {
+    fn new() -> Self {
+        Self {
+            enabled: false,
+            ep_in: None,
+            ep_out: None,
+        }
+    }
+}
+
+impl UsbBus for DummyUsbBus {
+    fn alloc_ep(
+        &mut self,
+        ep_dir: UsbDirection,
+        _ep_addr: Option<EndpointAddress>,
+        ep_type: EndpointType,
+        max_packet_size: u16,
+        _interval: u8,
+    ) -> usb_device::Result<EndpointAddress> {
+        assert!(!self.inner.lock().unwrap().enabled);
+
+        const EP_OUT_ADDR: usize = 0xFF;
+        const EP_IN_ADDR: usize = 0xEE;
+        const EP_CTRL: usize = 0;
+
+        if matches!(ep_type, EndpointType::Control) {
+            return Ok(EndpointAddress::from(EP_CTRL as u8));
+        }
+
+        let mut lock = self.inner.lock().unwrap();
+        let addr = match ep_dir {
+            UsbDirection::Out => {
+                let addr = EndpointAddress::from(EP_OUT_ADDR as u8);
+                lock.ep_out.replace(DummyEp::new(addr, max_packet_size));
+                addr
+            }
+            UsbDirection::In => {
+                let addr = EndpointAddress::from(EP_IN_ADDR as u8);
+                lock.ep_in.replace(DummyEp::new(addr, max_packet_size));
+                addr
+            }
+        };
+
+        Ok(addr)
+    }
+
+    fn enable(&mut self) {
+        self.inner.lock().unwrap().enabled = true;
+    }
+
+    fn reset(&self) {}
+
+    fn set_device_address(&self, _addr: u8) {}
+
+    fn write(&self, ep_addr: EndpointAddress, buf: &[u8]) -> usb_device::Result<usize> {
+        let mut lock = self.inner.lock().unwrap();
+        let ep = lock.ep_in.as_mut().unwrap();
+
+        if ep.addr != ep_addr {
+            return Err(UsbError::InvalidEndpoint);
+        }
+
+        if buf.len() > ep.max_packet_size as usize {
+            return Err(UsbError::BufferOverflow);
+        }
+
+        ep.write_bytes(buf);
+
+        Ok(buf.len())
+    }
+
+    fn read(&self, ep_addr: EndpointAddress, buf: &mut [u8]) -> usb_device::Result<usize> {
+        let mut lock = self.inner.lock().unwrap();
+        let ep = lock.ep_out.as_mut().unwrap();
+
+        if ep.addr != ep_addr {
+            return Err(UsbError::InvalidEndpoint);
+        }
+
+        if let Some(n) = ep.packets.front().map(|p| p.len()) {
+            if n > buf.len() {
+                return Err(UsbError::BufferOverflow);
+            }
+        }
+
+        match ep.read_packet() {
+            Some(packet) => {
+                let n = packet.len();
+                buf[..n].copy_from_slice(&packet.as_slice());
+                Ok(n)
+            }
+            None => Err(UsbError::WouldBlock),
+        }
+    }
+
+    fn set_stalled(&self, ep_addr: EndpointAddress, stalled: bool) {
+        let mut lock = self.inner.lock().unwrap();
+
+        if let Some(ep) = lock.ep_in.as_mut() {
+            if ep.addr == ep_addr {
+                return ep.stalled = stalled;
+            }
+        }
+
+        if let Some(ep) = lock.ep_out.as_mut() {
+            if ep.addr == ep_addr {
+                return ep.stalled = stalled;
+            }
+        }
+    }
+
+    fn is_stalled(&self, ep_addr: EndpointAddress) -> bool {
+        let mut lock = self.inner.lock().unwrap();
+
+        if let Some(ep) = lock.ep_in.as_mut() {
+            if ep.addr == ep_addr {
+                return ep.stalled;
+            }
+        }
+
+        if let Some(ep) = lock.ep_out.as_mut() {
+            if ep.addr == ep_addr {
+                return ep.stalled;
+            }
+        }
+
+        false
+    }
+
+    fn suspend(&self) {}
+
+    fn resume(&self) {}
+
+    fn poll(&self) -> PollResult {
+        PollResult::None
+    }
+}

--- a/usbd-storage/tests/common/mod.rs
+++ b/usbd-storage/tests/common/mod.rs
@@ -1,0 +1,86 @@
+use std::sync::mpsc::sync_channel;
+use std::thread;
+use std::time::Duration;
+use usbd_storage::subclass::Command;
+
+pub mod bbb;
+pub mod scsi;
+
+pub const PACKET_SIZE: [u16; 4] = [8, 16, 32, 64];
+
+pub enum Step<BUS, CMD, CLASS> {
+    /// Read/Write data on the Host side
+    HostIo(fn(&BUS) -> ()),
+    /// Drive Device until no pending IO operations left
+    DevIo,
+    /// Handle a command on the Device side
+    DevCmdHandle(fn(Command<CMD, CLASS>) -> ()),
+}
+
+// perhaps not the best way, but it's easier that battling against escaped borrows in closures
+#[macro_export]
+macro_rules! run_on_scsi_bbb_bus_timed {
+    { $timeout:expr, $steps:expr } => {
+            use common;
+
+            common::timeout($timeout, || {
+            for packet_size in common::PACKET_SIZE {
+                let steps = $steps;
+
+                let mut io_buf = [0u8; 1024];
+                let dummy_bus = DummyUsbBus::new();
+                let usb_bus = UsbBusAllocator::new(dummy_bus.clone());
+                let mut scsi = Scsi::new(&usb_bus, packet_size, 0, io_buf.as_mut_slice()).unwrap();
+                let _ = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0xabcd, 0xabcd)).build();
+
+                for step in &steps {
+                    match step {
+                        Step::DevIo => {
+                            let mut bytes_processed = dummy_bus.bytes_processed();
+                            loop {
+                                scsi.poll(|_| {}).unwrap();
+                                let new = dummy_bus.bytes_processed();
+                                if new == bytes_processed {
+                                    break;
+                                } else {
+                                    bytes_processed = new;
+                                }
+                            }
+                        }
+                        Step::HostIo(func) => {
+                            func(&dummy_bus);
+                        }
+                        Step::DevCmdHandle(func) => {
+                            let mut command_processed = false;
+                            loop {
+                                scsi.poll(|command| {
+                                    func(command);
+                                    command_processed = true;
+                                })
+                                    .unwrap();
+
+                                if command_processed {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    };
+}
+
+pub fn timeout<F, T>(timeout: Duration, f: F)
+where
+    F: FnOnce() -> T,
+    F: Send + 'static,
+    T: Send + 'static,
+{
+    let (tx, rx) = sync_channel(0);
+    thread::spawn(move || {
+        f();
+        tx.send(()).unwrap();
+    });
+    rx.recv_timeout(timeout).expect("timeout");
+}

--- a/usbd-storage/tests/common/scsi.rs
+++ b/usbd-storage/tests/common/scsi.rs
@@ -1,0 +1,96 @@
+use usbd_storage::subclass::scsi::ScsiCommand;
+
+const UNKNOWN: u8 = 0xFF;
+const TEST_UNIT_READY: u8 = 0x00;
+const REQUEST_SENSE: u8 = 0x03;
+const INQUIRY: u8 = 0x12;
+const MODE_SENSE_6: u8 = 0x1A;
+const MODE_SENSE_10: u8 = 0x5A;
+const READ_10: u8 = 0x28;
+const READ_CAPACITY_10: u8 = 0x25;
+const READ_CAPACITY_16: u8 = 0x9E;
+const WRITE_10: u8 = 0x2A;
+const READ_FORMAT_CAPACITIES: u8 = 0x23;
+
+pub fn cmd_into_bytes(cmd: ScsiCommand) -> Vec<u8> {
+    let mut bytes = vec![];
+    match cmd {
+        ScsiCommand::Unknown => {
+            bytes.push(UNKNOWN);
+        }
+        ScsiCommand::Inquiry {
+            evpd,
+            page_code,
+            alloc_len,
+        } => {
+            bytes.push(INQUIRY);
+            bytes.push(evpd as u8);
+            bytes.push(page_code);
+            bytes.extend_from_slice(alloc_len.to_be_bytes().as_slice());
+        }
+        ScsiCommand::TestUnitReady => {
+            bytes.push(TEST_UNIT_READY);
+        }
+        ScsiCommand::RequestSense { desc, alloc_len } => {
+            bytes.push(REQUEST_SENSE);
+            bytes.push(desc as u8);
+            bytes.extend_from_slice([0; 2].as_slice());
+            bytes.push(alloc_len);
+        }
+        ScsiCommand::ModeSense6 {
+            dbd,
+            page_control,
+            page_code,
+            subpage_code,
+            alloc_len,
+        } => {
+            bytes.push(MODE_SENSE_6);
+            bytes.push((dbd as u8) << 4);
+            bytes.push(((page_control as u8) << 6) & (page_code & 0b00111111));
+            bytes.push(subpage_code);
+            bytes.push(alloc_len);
+        }
+        ScsiCommand::ModeSense10 {
+            dbd,
+            page_control,
+            page_code,
+            subpage_code,
+            alloc_len,
+        } => {
+            bytes.push(MODE_SENSE_10);
+            bytes.push((dbd as u8) << 4);
+            bytes.push(((page_control as u8) << 6) & (page_code & 0b00111111));
+            bytes.push(subpage_code);
+            bytes.extend_from_slice([0; 3].as_slice());
+            bytes.extend_from_slice(alloc_len.to_be_bytes().as_slice());
+        }
+        ScsiCommand::ReadCapacity10 => {
+            bytes.push(READ_CAPACITY_10);
+        }
+        ScsiCommand::ReadCapacity16 { alloc_len } => {
+            bytes.push(READ_CAPACITY_16);
+            bytes.extend_from_slice([0; 10].as_slice());
+            bytes.extend_from_slice(alloc_len.to_be_bytes().as_slice());
+        }
+        ScsiCommand::Read { lba, len } => {
+            bytes.push(READ_10);
+            bytes.push(0);
+            bytes.extend_from_slice((lba as u32).to_be_bytes().as_slice());
+            bytes.push(0);
+            bytes.extend_from_slice((len as u16).to_be_bytes().as_slice());
+        }
+        ScsiCommand::Write { lba, len } => {
+            bytes.push(WRITE_10);
+            bytes.push(0);
+            bytes.extend_from_slice((lba as u32).to_be_bytes().as_slice());
+            bytes.push(0);
+            bytes.extend_from_slice((len as u16).to_be_bytes().as_slice());
+        }
+        ScsiCommand::ReadFormatCapacities { alloc_len } => {
+            bytes.push(READ_FORMAT_CAPACITIES);
+            bytes.extend_from_slice([0; 6].as_slice());
+            bytes.extend_from_slice(alloc_len.to_be_bytes().as_slice());
+        }
+    }
+    bytes
+}

--- a/usbd-storage/tests/scsi_bbb.rs
+++ b/usbd-storage/tests/scsi_bbb.rs
@@ -1,0 +1,156 @@
+mod common;
+
+use crate::common::bbb::{CommandStatus, DataDirection, DummyUsbBus, CBW, CSW};
+use crate::common::scsi::cmd_into_bytes;
+use crate::common::Step;
+use std::time::Duration;
+use usb_device::bus::UsbBusAllocator;
+use usb_device::device::{UsbDeviceBuilder, UsbVidPid};
+use usbd_storage::subclass::scsi::{Scsi, ScsiCommand};
+use usbd_storage::subclass::Command;
+use usbd_storage::transport::bbb::BulkOnly;
+
+const TIMEOUT: Duration = Duration::from_secs(1);
+
+#[test]
+fn should_fail_reading_data_from_host_with_bytes_read() {
+    run_on_scsi_bbb_bus_timed! { TIMEOUT, [
+        Step::HostIo(|bus: &DummyUsbBus| {
+            let cbw = CBW {
+                data_transfer_len: 512,
+                direction: DataDirection::Out,
+                block: cmd_into_bytes(ScsiCommand::Write { lba: 0, len: 1 }),
+            };
+            bus.write_cbw(cbw);
+            bus.write_data([0u8; 512].as_slice()); // host has written a block
+        }),
+        Step::DevIo,
+        Step::DevCmdHandle(
+            |cmd: Command<ScsiCommand, Scsi<BulkOnly<DummyUsbBus, &mut [u8]>>>| {
+                cmd.fail();
+            },
+        ),
+        Step::DevIo,
+        Step::HostIo(|bus: &DummyUsbBus| {
+            let expected_csw = CSW {
+                data_transfer_len: 0, // read all
+                status: CommandStatus::Failed,
+            };
+            assert_eq!(expected_csw, bus.read_cs().unwrap());
+        }),
+    ] }
+}
+
+#[test]
+fn should_fail_reading_data_from_host_without_bytes_read() {
+    run_on_scsi_bbb_bus_timed! { TIMEOUT, [
+        Step::HostIo(|bus: &DummyUsbBus| {
+            let cbw = CBW {
+                data_transfer_len: 512,
+                direction: DataDirection::Out,
+                block: cmd_into_bytes(ScsiCommand::Write { lba: 0, len: 1 }),
+            };
+            bus.write_cbw(cbw);
+        }),
+        Step::DevIo,
+        Step::DevCmdHandle(
+            |cmd: Command<ScsiCommand, Scsi<BulkOnly<DummyUsbBus, &mut [u8]>>>| {
+                cmd.fail_phase();
+            },
+        ),
+        Step::DevIo,
+        Step::HostIo(|bus: &DummyUsbBus| {
+            let expected_csw = CSW {
+                data_transfer_len: 512,
+                status: CommandStatus::PhaseError,
+            };
+            assert_eq!(expected_csw, bus.read_cs().unwrap());
+        }),
+    ] }
+}
+
+#[test]
+fn should_pass_reading_data_from_host_with_bytes_read() {
+    run_on_scsi_bbb_bus_timed! { TIMEOUT, [
+        Step::HostIo(|bus: &DummyUsbBus| {
+            let cbw = CBW {
+                data_transfer_len: 512,
+                direction: DataDirection::Out,
+                block: cmd_into_bytes(ScsiCommand::Write { lba: 0, len: 1 }),
+            };
+            bus.write_cbw(cbw);
+            bus.write_data([0u8; 512].as_slice()); // host has written a block
+        }),
+        Step::DevIo,
+        Step::DevCmdHandle(
+            |cmd: Command<ScsiCommand, Scsi<BulkOnly<DummyUsbBus, &mut [u8]>>>| {
+                cmd.pass();
+            },
+        ),
+        Step::DevIo,
+        Step::HostIo(|bus: &DummyUsbBus| {
+            let expected_csw = CSW {
+                data_transfer_len: 0, // read all
+                status: CommandStatus::Passed,
+            };
+            assert_eq!(expected_csw, bus.read_cs().unwrap());
+        }),
+    ] }
+}
+
+#[test]
+fn should_phase_fail_reading_data_from_host_trying_to_pass_without_bytes_read() {
+    run_on_scsi_bbb_bus_timed! { TIMEOUT, [
+        Step::HostIo(|bus: &DummyUsbBus| {
+            let cbw = CBW {
+                data_transfer_len: 512,
+                direction: DataDirection::Out,
+                block: cmd_into_bytes(ScsiCommand::Write { lba: 0, len: 1 }),
+            };
+            bus.write_cbw(cbw);
+        }),
+        Step::DevIo,
+        Step::DevCmdHandle(
+            |cmd: Command<ScsiCommand, Scsi<BulkOnly<DummyUsbBus, &mut [u8]>>>| {
+                cmd.fail_phase();
+            },
+        ),
+        Step::DevIo,
+        Step::HostIo(|bus: &DummyUsbBus| {
+            let expected_csw = CSW {
+                data_transfer_len: 512,
+                status: CommandStatus::PhaseError,
+            };
+            assert_eq!(expected_csw, bus.read_cs().unwrap());
+        }),
+    ] }
+}
+
+#[test]
+fn should_fail_in_the_middle_writing_data_to_host() {
+    run_on_scsi_bbb_bus_timed! { TIMEOUT, [
+        Step::HostIo(|bus: &DummyUsbBus| {
+            let cbw = CBW {
+                data_transfer_len: 512,
+                direction: DataDirection::In,
+                block: cmd_into_bytes(ScsiCommand::Read { lba: 0, len: 1 }),
+            };
+            bus.write_cbw(cbw);
+        }),
+        Step::DevCmdHandle(
+            |mut cmd: Command<ScsiCommand, Scsi<BulkOnly<DummyUsbBus, &mut [u8]>>>| {
+                assert_eq!(256, cmd.write_data([0xFFu8; 256].as_slice()).unwrap());
+                cmd.fail();
+            },
+        ),
+        Step::DevIo,
+        Step::HostIo(|bus: &DummyUsbBus| {
+            assert_eq!(256, bus.read_n_bytes(256).len()); // skip data bytes
+            let expected_csw = CSW {
+                data_transfer_len: 256,
+                status: CommandStatus::Failed,
+            };
+            assert_eq!(expected_csw, bus.read_cs().unwrap());
+        }),
+    ] }
+}


### PR DESCRIPTION
https://github.com/apohrebniak/usbd-storage/issues/1

The problem was with the Host->Device data transfers: it was required for IO buffer to be empty, but it wasn't possible for a user to read from it.
Fixed by ignoring the state of IO buffer if status is present. The issue doesn't exist for Device->Host data transfers (although it is needed to confirmed by tests)

~~TODO: Tests
    * Host->Dev transfer, bytes in the buffer, pass/fail/phase => does
      not stuck, CS is written;
    * Host->Dev transfer, NO bytes in the buffer, pass/fail/phase => does
      not stuck, CS is written;
    * Dev->Host transfer, bytes in the buffer, pass/fail/phase => does
      not stuck, buffer flushed, CS is written~~