### PR TITLE
Extended addressing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Adds a `extended_addressing` feature that enables 64-bit LBA and 32-bit LEN SCSI commands (https://github.com/apohrebniak/usbd-storage/pull/17)
 - Add RP2040 example (https://github.com/apohrebniak/usbd-storage/pull/16)
 - Store a number of unknown command (https://github.com/apohrebniak/usbd-storage/pull/7)
 - Upgrade defmt to v.1.0.0 (https://github.com/apohrebniak/usbd-storage/pull/14)

--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ Currently, only `Bulk Only` transport is implemented. It is possible to implemen
 # Features
 This crate has a couple of opt-in features that all could be used independently.
 
-| Feature | Description                                                      |
-|---------|------------------------------------------------------------------|
-| `bbb`   | Include Bulk Only Transport                                      |
-| `scsi`  | Include SCSI subclass                                            |
-| `ufi`   | Include USB Floppy Interface subclass                            |
-| `defmt` | Enable logging via [defmt](https://crates.io/crates/defmt) crate |
+| Feature               | Description                                                      |
+|-----------------------|------------------------------------------------------------------|
+| `bbb`                 | Include Bulk Only Transport                                      |
+| `scsi`                | Include SCSI subclass                                            |
+| `ufi`                 | Include USB Floppy Interface subclass                            |
+| `defmt`               | Enable logging via [defmt](https://crates.io/crates/defmt) crate |
+| `extended_addressing` | Enable commands that support 64-bit LBA and 32-bit LEN           |
 
 # Examples
 See [examples](examples)

--- a/examples/rp2040/src/bin/rp2040_scsi_bbb.rs
+++ b/examples/rp2040/src/bin/rp2040_scsi_bbb.rs
@@ -240,8 +240,8 @@ fn process_command(
             command.pass();
         }
         ScsiCommand::Read { lba, len } => critical_section::with(|cs| {
-            let lba = lba as u32;
             let len = len as u32;
+
             let mut state = STATE.borrow_ref_mut(cs);
 
             if state.storage_offset != (len * BLOCK_SIZE) as usize {
@@ -262,7 +262,6 @@ fn process_command(
             Ok(())
         })?,
         ScsiCommand::Write { lba, len } => critical_section::with(|cs| {
-            let lba = lba as u32;
             let len = len as u32;
 
             let mut state = STATE.borrow_ref_mut(cs);

--- a/examples/stm32/src/bin/stm32f411x_scsi_bbb.rs
+++ b/examples/stm32/src/bin/stm32f411x_scsi_bbb.rs
@@ -226,8 +226,8 @@ fn process_command(
             command.pass();
         }
         ScsiCommand::Read { lba, len } => critical_section::with(|cs| {
-            let lba = lba as u32;
             let len = len as u32;
+
             let mut state = STATE.borrow_ref_mut(cs);
 
             if state.storage_offset != (len * BLOCK_SIZE) as usize {
@@ -248,8 +248,8 @@ fn process_command(
             Ok(())
         })?,
         ScsiCommand::Write { lba, len } => critical_section::with(|cs| {
-            let lba = lba as u32;
             let len = len as u32;
+
             let mut state = STATE.borrow_ref_mut(cs);
 
             if state.storage_offset != (len * BLOCK_SIZE) as usize {

--- a/usbd-storage/Cargo.toml
+++ b/usbd-storage/Cargo.toml
@@ -28,11 +28,13 @@ defmt = ["dep:defmt", "usb-device/defmt"]
 bbb = []
 ufi = []
 scsi = []
+extended_addressing = []
 
 [[test]]
 name = "scsi_bbb"
-required-features = ["scsi", "bbb"]
+required-features = ["scsi", "bbb", "extended_addressing"]
 
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+

--- a/usbd-storage/tests/common/scsi.rs
+++ b/usbd-storage/tests/common/scsi.rs
@@ -6,10 +6,10 @@ const REQUEST_SENSE: u8 = 0x03;
 const INQUIRY: u8 = 0x12;
 const MODE_SENSE_6: u8 = 0x1A;
 const MODE_SENSE_10: u8 = 0x5A;
-const READ_10: u8 = 0x28;
+const READ_16: u8 = 0x88;
 const READ_CAPACITY_10: u8 = 0x25;
 const READ_CAPACITY_16: u8 = 0x9E;
-const WRITE_10: u8 = 0x2A;
+const WRITE_16: u8 = 0x8A;
 const READ_FORMAT_CAPACITIES: u8 = 0x23;
 
 pub fn cmd_into_bytes(cmd: ScsiCommand) -> Vec<u8> {
@@ -73,18 +73,18 @@ pub fn cmd_into_bytes(cmd: ScsiCommand) -> Vec<u8> {
             bytes.extend_from_slice(alloc_len.to_be_bytes().as_slice());
         }
         ScsiCommand::Read { lba, len } => {
-            bytes.push(READ_10);
+            bytes.push(READ_16);
             bytes.push(0);
-            bytes.extend_from_slice((lba as u32).to_be_bytes().as_slice());
+            bytes.extend_from_slice(lba.to_be_bytes().as_slice());
             bytes.push(0);
-            bytes.extend_from_slice((len as u16).to_be_bytes().as_slice());
+            bytes.extend_from_slice(len.to_be_bytes().as_slice());
         }
         ScsiCommand::Write { lba, len } => {
-            bytes.push(WRITE_10);
+            bytes.push(WRITE_16);
             bytes.push(0);
-            bytes.extend_from_slice((lba as u32).to_be_bytes().as_slice());
+            bytes.extend_from_slice(lba.to_be_bytes().as_slice());
             bytes.push(0);
-            bytes.extend_from_slice((len as u16).to_be_bytes().as_slice());
+            bytes.extend_from_slice(len.to_be_bytes().as_slice());
         }
         ScsiCommand::ReadFormatCapacities { alloc_len } => {
             bytes.push(READ_FORMAT_CAPACITIES);


### PR DESCRIPTION
Closes https://github.com/apohrebniak/usbd-storage/issues/8
Closes https://github.com/apohrebniak/usbd-storage/pull/12

Adds a `extended_addressing` feature that enables 64-bit LBA and 32-bit LEN SCSI commands