### PR TITLE
Fix unsound unsafe code in `Buffer::shift`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix unsoundness issue in internal use of `BulkOnly`s buffer (https://github.com/apohrebniak/usbd-storage/pull/21)
+
 ## [2.0.0] - 2025-11-13
 
 ### Changed

--- a/usbd-storage/src/buffer.rs
+++ b/usbd-storage/src/buffer.rs
@@ -78,13 +78,7 @@ impl<T: BorrowMut<[u8]>> Buffer<T> {
 
     fn shift(&mut self) {
         if self.rpos != self.wpos {
-            unsafe {
-                core::ptr::copy(
-                    &self.inner.borrow()[self.rpos] as *const u8,
-                    &mut self.inner.borrow_mut()[0] as *mut u8,
-                    self.available_read(),
-                )
-            }
+            self.inner.borrow_mut().copy_within(self.rpos..self.wpos, 0);
             self.wpos -= self.rpos;
             self.rpos = 0;
         } else {

--- a/usbd-storage/src/transport/bbb.rs
+++ b/usbd-storage/src/transport/bbb.rs
@@ -351,18 +351,16 @@ where
 
     fn check_end_data_transfer(&mut self) -> BulkOnlyTransportResult<()> {
         match self.state {
-            State::DataTransferNoData | State::DataTransferFromHost => {
+            State::DataTransferNoData | State::DataTransferFromHost
                 // command is passed or failed. IO buffer is irrelevant. end data transfer
-                if self.cs.is_some() {
+                if self.cs.is_some() => {
                     self.end_data_transfer()?;
                 }
-            }
-            State::DataTransferToHost => {
+            State::DataTransferToHost
                 // command is passed or failed. empty IO buffer first. if empty, end data transfer
-                if self.cs.is_some() && self.buf.available_read() == 0 {
+                if self.cs.is_some() && self.buf.available_read() == 0 => {
                     self.end_data_transfer()?;
                 }
-            }
             _ => {}
         }
 


### PR DESCRIPTION
The `unsafe` code in `Buffer::shift` is currently unsound because it holds a mutable and an immutable borrow to `self.inner` at the same time, which is forbidden under Rust's Stacked Borrows memory model and thus undefined behavior.

This can be confirmed by running `cargo +nightly miri test --lib --features bbb` in `./usbd-storage`.
Miri reports a Stacked Borrows violation (UB) in the `write_all_shift` test:
1. `&self.inner.borrow()[self.rpos] as *const u8` derives the source pointer from a shared borrow (`Borrow::borrow` -> `&[u8]`).
2. Both arguments are temporaries that live until the end of the full expression, so the shared borrow is still "alive" when the next argument is evaluated.
3. `&mut self.inner.borrow_mut()[0]` then takes a mutable borrow (`BorrowMut::borrow_mut` -> `&mut [u8]`) of the same array. Creating that `&mut` performs a "Unique retag" that invalidates the source pointer's tag.
4. `ptr::copy` then reads from the now-invalidated source -> UB.

---

This PR replaces the unsound `core::ptr::copy` invocation in `Buffer::shift` with slice primitive's safe `copy_within`.

Incidentally this also makes the library code totally free of `unsafe` code, which is generally nice to have!