### PR TITLE
BOT: remove panic paths from the transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Remove panic paths from the Bulk Only Transport (https://github.com/apohrebniak/usbd-storage/pull/25)
 - Rust 2024 edition (https://github.com/apohrebniak/usbd-storage/pull/22)
 - Fix unsoundness issue in internal use of `BulkOnly`s buffer (https://github.com/apohrebniak/usbd-storage/pull/21)
 

--- a/usbd-storage/src/fmt.rs
+++ b/usbd-storage/src/fmt.rs
@@ -34,6 +34,18 @@ macro_rules! debug {
     };
 }
 
+macro_rules! warning {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            #[cfg(feature = "defmt")]
+            ::defmt::warn!($s $(, $x)*);
+            #[cfg(not(feature="defmt"))]
+            let _ = ($( & $x ),*);
+        }
+    };
+}
+
 pub(crate) use debug;
 pub(crate) use info;
 pub(crate) use trace;
+pub(crate) use warning;

--- a/usbd-storage/src/transport/bbb.rs
+++ b/usbd-storage/src/transport/bbb.rs
@@ -1,7 +1,7 @@
 //! Bulk Only Transport (BBB/BOT)
 
 use crate::buffer::Buffer;
-use crate::fmt::{info, trace};
+use crate::fmt::{info, trace, warning};
 use crate::transport::{CommandStatus, Transport, TransportError};
 use core::borrow::BorrowMut;
 use core::cmp::min;
@@ -207,15 +207,16 @@ where
         if !matches!(self.state, State::DataTransferFromHost) {
             return Err(TransportError::Error(BulkOnlyError::InvalidState));
         }
+        // The closure always returns Ok, so the outer Result is always Ok too.
         Ok(self
             .buf
             .read(|buf| {
                 // fill 'dst' or however much is in 'buf'
                 let size = min(dst.len(), buf.len());
                 dst[..size].copy_from_slice(&buf[..size]);
-                Ok::<usize, ()>(size)
+                Ok::<usize, core::convert::Infallible>(size)
             })
-            .unwrap())
+            .unwrap_or(0))
     }
 
     /// Writes data from the IO buffer returning the number of bytes actually written
@@ -383,7 +384,11 @@ where
         }
 
         // write CSW into buffer
-        let csw = self.build_csw().unwrap();
+        // cs must be Some here (enforced by check_end_data_transfer); report a
+        // transport error on a state-machine bug instead of panicking the device.
+        let csw = self
+            .build_csw()
+            .ok_or(TransportError::Error(BulkOnlyError::InvalidState))?;
         self.buf.clean();
         self.buf.write(csw.as_slice());
 
@@ -414,12 +419,13 @@ where
 
         // read CBW from buf
         let mut raw_cbw = [0u8; CBW_LEN];
+        // The closure always returns Ok; unwrap_or(0) is unreachable but avoids unwrap().
         self.buf
-            .read::<()>(|buf| {
+            .read::<core::convert::Infallible>(|buf| {
                 raw_cbw.copy_from_slice(&buf[..CBW_LEN]); // buf.len() checked in the beginning
                 Ok(CBW_LEN)
             })
-            .unwrap();
+            .unwrap_or(0);
 
         // check if CBW is valid. Spec. 6.2.1
         if !raw_cbw.starts_with(&CBW_SIGNATURE_LE) {
@@ -572,9 +578,12 @@ where
             CLASS_SPECIFIC_BULK_ONLY_MASS_STORAGE_RESET => {}
             // Spec. section 3.2
             CLASS_SPECIFIC_GET_MAX_LUN => {
-                // always respond with LUN
-                xfer.accept_with(&[self.max_lun])
-                    .expect("Failed to accept Get Max Lun!");
+                // always respond with LUN. A failure here means the host
+                // misbehaved or the bus glitched mid control-transfer; log and
+                // return rather than panicking the device.
+                if let Err(err) = xfer.accept_with(&[self.max_lun]) {
+                    warning!("usb: bbb: Get Max Lun accept failed: {}", err);
+                }
             }
             _ => {}
         }
@@ -603,21 +612,30 @@ impl CommandBlockWrapper {
             return Err(InvalidCbwError);
         }
 
-        Ok(CommandBlockWrapper {
-            tag: u32::from_le_bytes(value[..4].try_into().unwrap()),
-            data_transfer_len: u32::from_le_bytes(value[4..8].try_into().unwrap()),
-            direction: if u32::from_le_bytes(value[4..8].try_into().unwrap()) != 0 {
-                if (value[8] & (1 << 7)) > 0 {
-                    DataDirection::In
-                } else {
-                    DataDirection::Out
-                }
+        // These slices are always exactly 4 / 4 / 16 bytes given the CBW layout;
+        // map the (unreachable) TryInto failure to InvalidCbwError rather than
+        // unwrapping.
+        let tag = u32::from_le_bytes(value[..4].try_into().map_err(|_| InvalidCbwError)?);
+        let data_transfer_len =
+            u32::from_le_bytes(value[4..8].try_into().map_err(|_| InvalidCbwError)?);
+        let direction = if data_transfer_len != 0 {
+            if (value[8] & (1 << 7)) > 0 {
+                DataDirection::In
             } else {
-                DataDirection::NotExpected
-            },
+                DataDirection::Out
+            }
+        } else {
+            DataDirection::NotExpected
+        };
+        let block: [u8; 16] = value[11..].try_into().map_err(|_| InvalidCbwError)?;
+
+        Ok(CommandBlockWrapper {
+            tag,
+            data_transfer_len,
+            direction,
             lun: value[9] & 0b00001111,
             block_len: block_len as usize,
-            block: value[11..].try_into().unwrap(), // ok, because we checked a length
+            block,
         })
     }
 }


### PR DESCRIPTION
Follow-up to #23/#24, one layer up: the transport still has a handful of `unwrap`/`expect` calls in non-test code. In `no_std` firmware a panic means a hung or resetting device, so panic paths that a host or a transient USB error can reach are worth removing even when they are guarded today. To be clear about severity: unlike #23/#24, none of these have been observed firing — this is hardening, not a bug observed in the field.

- `end_data_transfer` built the CSW with `build_csw().unwrap()`. The call is guarded by `check_end_data_transfer`'s `cs.is_some()` checks, but if that invariant ever breaks the device panics mid-command; it now reports `BulkOnlyError::InvalidState` instead.
- The GET MAX LUN handler used `expect` on `accept_with`. `usb-device` can refuse a control transfer transiently, and this is a request hosts send at every enumeration — the worst possible moment to panic. It now logs a warning (new `warning!` level in `fmt.rs`, mapped to `defmt::warn!`) and lets the host retry.
- The remaining ones are provably unreachable but `unwrap`-shaped, which is noise for anyone auditing the crate for panic paths: the IO-buffer read closures in `read_data`/`try_parse_cbw` are infallible (now typed `core::convert::Infallible` with `unwrap_or(0)`), and the fixed-size slice conversions in `CommandBlockWrapper::from_le_bytes` can't fail given the length check (now mapped to `InvalidCbwError`). While there, `from_le_bytes` parses `data_transfer_len` once instead of three times — behavior unchanged.

No functional change for well-behaved hosts. `cargo test --all-features`, fmt and clippy are clean.