### PR TITLE
BOT: two spec-conformance fixes in the data phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- BBB: don't hand a command block to the subclass after an invalid CBW (https://github.com/apohrebniak/usbd-storage/pull/28)
+- BBB: never put more than `dCBWDataTransferLength` bytes on the Bulk-In pipe (https://github.com/apohrebniak/usbd-storage/pull/28)
+
 ## [3.0.0] - 2026-07-05
 
 ### Changed
@@ -59,4 +64,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.2.0]: https://github.com/apohrebniak/usbd-storage/releases/tag/v0.2.0
 [0.1.1]: https://github.com/apohrebniak/usbd-storage/releases/tag/v0.1.1
 [0.1.0]: https://github.com/apohrebniak/usbd-storage/releases/tag/v0.1.0
-

--- a/usbd-storage/src/transport/bbb.rs
+++ b/usbd-storage/src/transport/bbb.rs
@@ -412,7 +412,7 @@ where
 
         // allow a short packet if needed
         let bytes_sent = if self.left_to_transfer < self.packet_size() as u32 {
-            self.write_packet()?
+            self.write_packet(self.left_to_transfer as usize)?
         } else {
             self.try_write_full_packet()?
         };
@@ -432,7 +432,7 @@ where
             return self.handle_read_cbw();
         }
 
-        self.write_packet()?;
+        self.write_packet(CSW_LEN)?;
 
         Ok(())
     }
@@ -461,20 +461,14 @@ where
             return self.handle_status_transfer();
         }
 
+        // fill up to has_to_send if the subclass left us short
         let available = self.buf.available_read();
-
-        if available >= has_to_send {
-            // enough data to send a full packet
-            let bytes_written = self.write_packet()?;
-            self.mark_as_transferred(bytes_written as u32);
-        } else {
-            // fill up to has_to_send
-            let to_fill = has_to_send.saturating_sub(available);
-            self.buf.fill_up_to(FILL_BYTE, to_fill);
-
-            let bytes_written = self.write_packet()?;
-            self.mark_as_transferred(bytes_written as u32);
+        if available < has_to_send {
+            self.buf.fill_up_to(FILL_BYTE, has_to_send - available);
         }
+
+        let bytes_written = self.write_packet(has_to_send)?;
+        self.mark_as_transferred(bytes_written as u32);
 
         Ok(())
     }
@@ -607,13 +601,21 @@ where
 
     /// Tries to write a single packet into IN EP returning the number of bytes actually written
     ///
-    /// Might write a short packet if not enough data was in the buffer
-    fn write_packet(&mut self) -> BulkOnlyTransportResult<usize> {
-        let packet_size = self.packet_size();
+    /// Might write a short packet if not enough data was in the buffer.
+    ///
+    /// `max` caps how many bytes may go on the wire, on top of the packet size and
+    /// whatever the buffer holds. During a Data-In transfer that cap is the number of
+    /// bytes the host still expects, so a subclass that staged more than
+    /// `dCBWDataTransferLength` cannot make the device overrun the host's buffer
+    /// (Spec. 6.7.2: the device may send data up to a total of
+    /// `dCBWDataTransferLength`). Bytes staged beyond the cap are dropped when the
+    /// Status Transfer state cleans the buffer.
+    fn write_packet(&mut self, max: usize) -> BulkOnlyTransportResult<usize> {
+        let limit = min(self.packet_size(), max);
 
         let bytes_written = self.buf.read(|buf| {
             if !buf.is_empty() {
-                match self.in_ep.write(&buf[..min(packet_size, buf.len())]) {
+                match self.in_ep.write(&buf[..min(limit, buf.len())]) {
                     Ok(bytes_written) => {
                         trace!("usb: bbb: Wrote bytes: {}", bytes_written);
                         Ok(bytes_written)
@@ -639,7 +641,7 @@ where
             return Err(TransportError::Error(BulkOnlyError::FullPacketExpected));
         }
 
-        self.write_packet()
+        self.write_packet(self.packet_size())
     }
 }
 
@@ -962,6 +964,55 @@ mod tests {
         bbb.buf.write([0xFFu8; BUF_SIZE].as_slice()); // fill the buffer
 
         assert_eq!(N, bbb.read_data([0u8; N].as_mut_slice()).unwrap());
+    }
+
+    #[test]
+    fn short_data_in_request_is_not_overrun_by_try_write_data_all() {
+        // try_write_data_all applies no dCBWDataTransferLength cap -- it is meant for
+        // canned, fixed-size responses, which is how the examples answer INQUIRY,
+        // MODE SENSE and friends. When the host asks for fewer bytes than the canned
+        // response holds (ordinary host probing), the transport must still put only
+        // dCBWDataTransferLength bytes on the wire. Spec. 6.7.2.
+        const D: u32 = 4; // host asks for 4 bytes
+
+        for ps in PACKET_SIZES {
+            let (csw, data) = run(ps, D, Host::ExpectsDataIn, |b| {
+                b.try_write_data_all(&[0xAA; 36]).unwrap(); // canned INQUIRY response
+                b.set_status(CommandStatus::Passed, 36);
+            });
+            assert_eq!(data.len(), D as usize, "ps={ps}");
+            assert_eq!(csw.status, 0, "ps={ps}");
+            assert_eq!(csw.residue, 0, "ps={ps}");
+        }
+    }
+
+    #[test]
+    fn overstaged_data_in_is_truncated_to_the_requested_length() {
+        // write_data caps each call against left_to_transfer -- the UNSENT budget --
+        // so a subclass writing in several rounds can stage more than
+        // dCBWDataTransferLength in total. The wire must still carry no more than
+        // the host asked for.
+        const PS: u16 = 64;
+        const D: u32 = 100;
+
+        let (shared, mut bbb) = new_bbb(PS);
+        enqueue(&shared, &cbw(D, Host::ExpectsDataIn), PS);
+        let _ = bbb.poll(); // read CBW, enter DataTransferToHost
+
+        assert_eq!(100, bbb.write_data(&[0xAA; 100]).unwrap());
+        let _ = bbb.poll(); // sends one full packet; left_to_transfer 100 -> 36
+        assert_eq!(36, bbb.write_data(&[0xBB; 100]).unwrap()); // total staged: 136
+
+        bbb.set_status(CommandStatus::Passed, D);
+        for _ in 0..64 {
+            let _ = bbb.poll();
+            if matches!(bbb.state, State::CommandTransfer) {
+                break;
+            }
+        }
+
+        let stream = std::mem::take(&mut *shared.input.lock().unwrap()).concat();
+        assert_eq!(stream.len() - CSW_LEN, D as usize);
     }
 
     #[test]

--- a/usbd-storage/src/transport/bbb.rs
+++ b/usbd-storage/src/transport/bbb.rs
@@ -786,7 +786,7 @@ mod tests {
     fn host_expects_no_data_device_sends_no_data() {
         // Case 1: Hn = Dn
         for ps in PACKET_SIZES {
-            let (csw, _) = run(ps, 0, Host::ExpectsNoData, |b| {
+            let (csw, _) = run(ps, 0, Host::NoData, |b| {
                 b.set_status(CommandStatus::Passed, 0)
             });
             assert_eq!(csw.status, 0, "ps={ps}");
@@ -798,7 +798,7 @@ mod tests {
     fn host_expects_no_data_device_wants_to_send() {
         // Case 2: Hn < Di -> Phase Error
         for ps in PACKET_SIZES {
-            let (csw, data) = run(ps, 0, Host::ExpectsNoData, |b| {
+            let (csw, data) = run(ps, 0, Host::NoData, |b| {
                 assert!(is_invalid_state(b.write_data(&[0xAA; 8])));
                 b.set_status(CommandStatus::PhaseError, 0);
             });
@@ -811,7 +811,7 @@ mod tests {
     fn host_expects_no_data_device_wants_to_receive() {
         // Case 3: Hn < Do -> Phase Error
         for ps in PACKET_SIZES {
-            let (csw, _) = run(ps, 0, Host::ExpectsNoData, |b| {
+            let (csw, _) = run(ps, 0, Host::NoData, |b| {
                 assert!(is_invalid_state(b.read_data(&mut [0u8; 8])));
                 b.set_status(CommandStatus::PhaseError, 0);
             });
@@ -825,7 +825,7 @@ mod tests {
     fn host_expects_data_in_device_sends_none() {
         // Case 4: Hi > Dn
         for ps in PACKET_SIZES {
-            let (csw, data) = run(ps, 32, Host::ExpectsDataIn, |b| {
+            let (csw, data) = run(ps, 32, Host::DataIn, |b| {
                 b.set_status(CommandStatus::Passed, 0)
             });
             assert_eq!(csw.status, 0, "ps={ps}");
@@ -838,7 +838,7 @@ mod tests {
     fn host_expects_more_data_in_than_device_sends() {
         // Case 5: Hi > Di
         for ps in PACKET_SIZES {
-            let (csw, data) = run(ps, 32, Host::ExpectsDataIn, |b| {
+            let (csw, data) = run(ps, 32, Host::DataIn, |b| {
                 let n = b.write_data(&[0xAA; 16]).unwrap();
                 b.set_status(CommandStatus::Passed, n as u32);
             });
@@ -852,7 +852,7 @@ mod tests {
     fn host_expects_exactly_what_device_sends() {
         // Case 6: Hi = Di
         for ps in PACKET_SIZES {
-            let (csw, data) = run(ps, 32, Host::ExpectsDataIn, |b| {
+            let (csw, data) = run(ps, 32, Host::DataIn, |b| {
                 let n = b.write_data(&[0xAA; 32]).unwrap();
                 b.set_status(CommandStatus::Passed, n as u32);
             });
@@ -866,7 +866,7 @@ mod tests {
     fn host_expects_less_data_in_than_device_sends() {
         // Case 7: Hi < Di -> Phase Error
         for ps in PACKET_SIZES {
-            let (csw, data) = run(ps, 16, Host::ExpectsDataIn, |b| {
+            let (csw, data) = run(ps, 16, Host::DataIn, |b| {
                 let n = b.write_data(&[0xAA; 32]).unwrap(); // capped to dCBWDataTransferLength
                 assert_eq!(n, 16); // device wanted to send more than the host allows
                 b.set_status(CommandStatus::PhaseError, 0);
@@ -880,7 +880,7 @@ mod tests {
     fn host_expects_data_in_device_wants_to_receive() {
         // Case 8: Hi <> Do -> Phase Error
         for ps in PACKET_SIZES {
-            let (csw, data) = run(ps, 32, Host::ExpectsDataIn, |b| {
+            let (csw, data) = run(ps, 32, Host::DataIn, |b| {
                 assert!(is_invalid_state(b.read_data(&mut [0u8; 32])));
                 b.set_status(CommandStatus::PhaseError, 0);
             });
@@ -895,7 +895,7 @@ mod tests {
     fn host_sends_data_device_receives_none() {
         // Case 9: Ho > Dn
         for ps in PACKET_SIZES {
-            let (csw, _) = run(ps, 32, Host::ExpectsDataOut, |b| {
+            let (csw, _) = run(ps, 32, Host::DataOut, |b| {
                 b.set_status(CommandStatus::Passed, 0)
             });
             assert_eq!(csw.status, 0, "ps={ps}");
@@ -907,7 +907,7 @@ mod tests {
     fn host_sends_data_device_wants_to_send() {
         // Case 10: Ho <> Di -> Phase Error
         for ps in PACKET_SIZES {
-            let (csw, _) = run(ps, 32, Host::ExpectsDataOut, |b| {
+            let (csw, _) = run(ps, 32, Host::DataOut, |b| {
                 assert!(is_invalid_state(b.write_data(&[0xAA; 8])));
                 b.set_status(CommandStatus::PhaseError, 0);
             });
@@ -919,7 +919,7 @@ mod tests {
     fn host_sends_more_data_out_than_device_receives() {
         // Case 11: Ho > Do
         for ps in PACKET_SIZES {
-            let (csw, _) = run(ps, 32, Host::ExpectsDataOut, |b| {
+            let (csw, _) = run(ps, 32, Host::DataOut, |b| {
                 let n = b.read_data(&mut [0u8; 16]).unwrap();
                 b.set_status(CommandStatus::Passed, n as u32);
             });
@@ -932,7 +932,7 @@ mod tests {
     fn host_sends_exactly_what_device_receives() {
         // Case 12: Ho = Do
         for ps in PACKET_SIZES {
-            let (csw, _) = run(ps, 32, Host::ExpectsDataOut, |b| {
+            let (csw, _) = run(ps, 32, Host::DataOut, |b| {
                 let n = b.read_data(&mut [0u8; 32]).unwrap();
                 b.set_status(CommandStatus::Passed, n as u32);
             });
@@ -945,7 +945,7 @@ mod tests {
     fn host_sends_less_data_out_than_device_receives() {
         // Case 13: Ho < Do -> Phase Error
         for ps in PACKET_SIZES {
-            let (csw, _) = run(ps, 16, Host::ExpectsDataOut, |b| {
+            let (csw, _) = run(ps, 16, Host::DataOut, |b| {
                 let n = b.read_data(&mut [0u8; 32]).unwrap(); // only what the host sent
                 assert_eq!(n, 16); // device wanted to receive more than the host sends
                 b.set_status(CommandStatus::PhaseError, 0);
@@ -976,7 +976,7 @@ mod tests {
         const D: u32 = 4; // host asks for 4 bytes
 
         for ps in PACKET_SIZES {
-            let (csw, data) = run(ps, D, Host::ExpectsDataIn, |b| {
+            let (csw, data) = run(ps, D, Host::DataIn, |b| {
                 b.try_write_data_all(&[0xAA; 36]).unwrap(); // canned INQUIRY response
                 b.set_status(CommandStatus::Passed, 36);
             });
@@ -996,7 +996,7 @@ mod tests {
         const D: u32 = 100;
 
         let (shared, mut bbb) = new_bbb(PS);
-        enqueue(&shared, &cbw(D, Host::ExpectsDataIn), PS);
+        enqueue(&shared, &cbw(D, Host::DataIn), PS);
         let _ = bbb.poll(); // read CBW, enter DataTransferToHost
 
         assert_eq!(100, bbb.write_data(&[0xAA; 100]).unwrap());
@@ -1024,7 +1024,7 @@ mod tests {
         for ps in PACKET_SIZES {
             let (shared, mut bbb) = new_bbb(ps);
 
-            let mut bad = cbw(0, Host::ExpectsNoData);
+            let mut bad = cbw(0, Host::NoData);
             bad[0] ^= 0xFF; // corrupt dCBWSignature
             enqueue(&shared, &bad, ps);
 
@@ -1044,11 +1044,12 @@ mod tests {
 
     const PACKET_SIZES: [u16; 4] = [8, 16, 32, 64];
 
+    /// What the host expects: Spec. 6.7's Hn / Hi / Ho.
     #[derive(Copy, Clone)]
     enum Host {
-        ExpectsNoData,
-        ExpectsDataIn,  // device -> host
-        ExpectsDataOut, // host -> device
+        NoData,  // Hn
+        DataIn,  // Hi: device -> host
+        DataOut, // Ho: host -> device
     }
 
     /// Queues shared between the test and the bus moved into the allocator.
@@ -1125,7 +1126,7 @@ mod tests {
         c[..4].copy_from_slice(&0x43425355u32.to_le_bytes());
         c[4..8].copy_from_slice(&1u32.to_le_bytes()); // tag
         c[8..12].copy_from_slice(&data_len.to_le_bytes());
-        c[12] = if matches!(host, Host::ExpectsDataIn) {
+        c[12] = if matches!(host, Host::DataIn) {
             0x80
         } else {
             0x00
@@ -1158,7 +1159,7 @@ mod tests {
         let (shared, mut bbb) = new_bbb(packet_size);
 
         enqueue(&shared, &cbw(data_len, host), packet_size);
-        if matches!(host, Host::ExpectsDataOut) {
+        if matches!(host, Host::DataOut) {
             enqueue(&shared, &vec![0xAA; data_len as usize], packet_size);
         }
 
@@ -1166,7 +1167,7 @@ mod tests {
         // spans several packets at small MTUs, so this may take multiple polls.
         for _ in 0..64 {
             let _ = bbb.poll();
-            let out_drained = !matches!(host, Host::ExpectsDataOut) || bbb.left_to_transfer == 0;
+            let out_drained = !matches!(host, Host::DataOut) || bbb.left_to_transfer == 0;
             if bbb.get_command().is_some() && out_drained {
                 break;
             }

--- a/usbd-storage/src/transport/bbb.rs
+++ b/usbd-storage/src/transport/bbb.rs
@@ -190,8 +190,16 @@ where
     }
 
     /// Returns a Command Block if present
+    ///
+    /// There is no command block while a CBW is still being received, and none
+    /// after an invalid one: per Spec. 6.6.1 an invalid CBW leaves the device
+    /// STALLing both pipes until a Reset Recovery, so `self.cbw` holds either
+    /// nothing at all or the previous command's block.
     pub fn get_command(&self) -> Option<CommandBlock<'_>> {
-        if matches!(self.state, State::CommandTransfer) {
+        if matches!(
+            self.state,
+            State::CommandTransfer | State::CommandTransferInvalid
+        ) {
             return None;
         }
 
@@ -954,6 +962,31 @@ mod tests {
         bbb.buf.write([0xFFu8; BUF_SIZE].as_slice()); // fill the buffer
 
         assert_eq!(N, bbb.read_data([0u8; N].as_mut_slice()).unwrap());
+    }
+
+    #[test]
+    fn invalid_cbw_yields_no_command_block() {
+        // Spec. 6.6.1: an invalid CBW is terminal until a Reset Recovery, so there
+        // is no command to hand to the subclass. Before this was guarded, a first
+        // CBW with a bad signature yielded a CommandBlock over an unpopulated
+        // CommandBlockWrapper -- an empty CDB, which panics subclass CDB parsers.
+        for ps in PACKET_SIZES {
+            let (shared, mut bbb) = new_bbb(ps);
+
+            let mut bad = cbw(0, Host::ExpectsNoData);
+            bad[0] ^= 0xFF; // corrupt dCBWSignature
+            enqueue(&shared, &bad, ps);
+
+            for _ in 0..64 {
+                let _ = bbb.poll();
+                if matches!(bbb.state, State::CommandTransferInvalid) {
+                    break;
+                }
+            }
+
+            assert_matches!(bbb.state, State::CommandTransferInvalid, "ps={ps}");
+            assert!(bbb.get_command().is_none(), "ps={ps}");
+        }
     }
 
     // ---- test harness ----

--- a/usbd-storage/tests/common/bbb.rs
+++ b/usbd-storage/tests/common/bbb.rs
@@ -289,10 +289,10 @@ impl UsbBus for DummyUsbBus {
             return Err(UsbError::InvalidEndpoint);
         }
 
-        if let Some(n) = ep.packets.front().map(|p| p.len()) {
-            if n > buf.len() {
-                return Err(UsbError::BufferOverflow);
-            }
+        if let Some(n) = ep.packets.front().map(|p| p.len())
+            && n > buf.len()
+        {
+            return Err(UsbError::BufferOverflow);
         }
 
         match ep.read_packet() {
@@ -308,32 +308,32 @@ impl UsbBus for DummyUsbBus {
     fn set_stalled(&self, ep_addr: EndpointAddress, stalled: bool) {
         let mut lock = self.inner.lock().unwrap();
 
-        if let Some(ep) = lock.ep_in.as_mut() {
-            if ep.addr == ep_addr {
-                return ep.stalled = stalled;
-            }
+        if let Some(ep) = lock.ep_in.as_mut()
+            && ep.addr == ep_addr
+        {
+            return ep.stalled = stalled;
         }
 
-        if let Some(ep) = lock.ep_out.as_mut() {
-            if ep.addr == ep_addr {
-                ep.stalled = stalled
-            }
+        if let Some(ep) = lock.ep_out.as_mut()
+            && ep.addr == ep_addr
+        {
+            ep.stalled = stalled
         }
     }
 
     fn is_stalled(&self, ep_addr: EndpointAddress) -> bool {
         let mut lock = self.inner.lock().unwrap();
 
-        if let Some(ep) = lock.ep_in.as_mut() {
-            if ep.addr == ep_addr {
-                return ep.stalled;
-            }
+        if let Some(ep) = lock.ep_in.as_mut()
+            && ep.addr == ep_addr
+        {
+            return ep.stalled;
         }
 
-        if let Some(ep) = lock.ep_out.as_mut() {
-            if ep.addr == ep_addr {
-                return ep.stalled;
-            }
+        if let Some(ep) = lock.ep_out.as_mut()
+            && ep.addr == ep_addr
+        {
+            return ep.stalled;
         }
 
         false

--- a/usbd-storage/tests/scsi_bbb.rs
+++ b/usbd-storage/tests/scsi_bbb.rs
@@ -13,6 +13,42 @@ use usbd_storage::transport::bbb::BulkOnly;
 
 const TIMEOUT: Duration = Duration::from_secs(1);
 
+/// A malformed CBW must not reach the subclass.
+///
+/// Spec. 6.6.1 makes an invalid CBW terminal until a Reset Recovery, so there is no
+/// command to dispatch. When `get_command` still reported one, the block came from an
+/// unpopulated `CommandBlockWrapper`; on the first CBW after power-up that is an empty
+/// CDB, and `scsi::parse_cb` indexes `cb[0]` -- an index-out-of-bounds panic in release
+/// builds, reachable from a single 31-byte packet on the wire.
+#[test]
+fn invalid_first_cbw_does_not_reach_the_subclass() {
+    let mut io_buf = [0u8; 1024];
+    let dummy_bus = DummyUsbBus::new();
+    let usb_bus = UsbBusAllocator::new(dummy_bus.clone());
+    let mut scsi = Scsi::new(&usb_bus, 64, 0, io_buf.as_mut_slice()).unwrap();
+    let _ = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0xabcd, 0xabcd)).build();
+
+    let mut bad = Cbw {
+        data_transfer_len: 0,
+        direction: DataDirection::NotExpected,
+        block: vec![0x12],
+    }
+    .into_bytes();
+    bad[0] ^= 0xFF; // corrupt dCBWSignature
+    dummy_bus.write_data(bad.as_slice());
+
+    scsi.poll(); // reads the CBW, enters the terminal invalid state
+
+    let mut dispatched = false;
+    scsi.poll_command(|_cmd| {
+        dispatched = true;
+        Ok(())
+    })
+    .unwrap();
+
+    assert!(!dispatched, "an invalid CBW was dispatched to the subclass");
+}
+
 #[test]
 fn should_fail_reading_data_from_host_with_bytes_processed() {
     run_on_scsi_bbb_bus_timed! { TIMEOUT, [


### PR DESCRIPTION
# BOT: two spec-conformance fixes in the data phase

Two independent fixes found while porting our RT1064 firmware onto v3.0.0. One commit each,
so you can take either on its own. Both come with regression tests that fail on `master`.

## 1. Don't hand a command block to the subclass after an invalid CBW

`get_command()` returns `Some` for every state except `CommandTransfer`, including the
terminal `CommandTransferInvalid`. Spec. 6.6.1 makes that state terminal until a Reset
Recovery, so there is no command to dispatch — but the subclass gets a `CommandBlock`
built over `self.cbw`, which at that point holds either the _previous_ command's block or,
on the first CBW after power-up, nothing at all.

Nothing at all means `block_len == 0`, i.e. an empty CDB, and `scsi::parse_cb` opens with
`match (cb[0], cb.len())`:

```
debug:   panicked at src/subclass/scsi.rs:131: assertion failed: !cb.is_empty()
release: panicked at src/subclass/scsi.rs:133: index out of bounds: the len is 0 but the index is 0
```

Reachable from a single 31-byte packet — a corrupted `dCBWSignature`, or a `bCBWCBLength`
outside 1..=16, as the first CBW after enumeration. Fix is to report no command in that
state.

## 2. Never put more than `dCBWDataTransferLength` on the Bulk-In pipe

Spec. 6.7.2 caps the Data-In phase: _"The device may send data up to a total of
dCBWDataTransferLength."_ Today it can exceed it, because nothing clamps the wire write:

- `write_packet()` writes `min(packet_size, buf.len())`, with no reference to
  `left_to_transfer`;
- `write_data()` caps each call against `left_to_transfer` — the _unsent_ budget rather
  than the _unwritten_ one — so a subclass writing in several rounds can stage more than
  `dCBWDataTransferLength` in total;
- `try_write_data_all()` applies no length cap at all.

That last one is the easy one to hit, because `try_write_data_all` is exactly what the
examples use for canned fixed-size responses. `rp2040_scsi_bbb.rs` answers INQUIRY with a
36-byte array; when a host asks for fewer bytes — ordinary probing, not an attack — the
device puts all 36 on the wire:

```
dCBWDataTransferLength = 4, handler writes 36 bytes  ->  36 bytes on the wire
```

Fix is a `max` argument on `write_packet`, passed as the number of bytes the host still
expects during a Data-In transfer and as `CSW_LEN` during the Status Transfer. Bytes
staged past the cap are dropped when the Status Transfer state cleans the buffer. This
also makes the `DataTransferToHostEnding` fill path honour `has_to_send`, which it
previously computed and then ignored; with both branches now identical apart from the
fill, they collapse into one.

I deliberately left `write_data`/`try_write_data_all` alone: changing what they accept
would change their contract, and clamping the wire is enough to keep the device inside the
spec. Happy to add a cap there too if you'd rather the staging APIs refuse the bytes up
front.

## Testing

- `cargo test -p usbd-storage --all-features`, debug and release
- `cargo clippy -p usbd-storage --target thumbv7em-none-eabihf --all-features` and
  `--target thumbv6m-none-eabi`: clean
- `cargo fmt --check`: clean

New tests: `invalid_cbw_yields_no_command_block`,
`invalid_first_cbw_does_not_reach_the_subclass`,
`short_data_in_request_is_not_overrun_by_try_write_data_all`,
`overstaged_data_in_is_truncated_to_the_requested_length`.

## Last commit is unrelated

`style(tests): clear the clippy warnings in the test harness` clears the six warnings
`cargo clippy --all-features --all-targets` reports on `master` — five collapsible
`if let`s in `tests/common/bbb.rs` (via `cargo clippy --fix`) and the `enum_variant_names`
lint on the `Host` test enum, whose variants I shortened to `NoData` / `DataIn` / `DataOut`
since the enum name already says "host". CI only lints the lib target so these never fire
there. It's a separate commit precisely so you can drop it if you'd rather not have it in
here.

## One more, flagged rather than fixed

There's a third thing I'm confident is a defect, but every fix I can think of adds public
API, so I'd rather flag it than presume a shape: the Bulk-Only Mass Storage Reset can't
currently be received. Spec. 3.1 Table 3.1 gives it `bmRequestType` = `00100001b`, i.e.
host-to-device, so `usb-device` dispatches it to `UsbClass::control_out` — and the crate
implements `control_out` nowhere, so the `CLASS_SPECIFIC_BULK_ONLY_MASS_STORAGE_RESET` arm
in `control_in` never runs and `usb-device` rejects the request. The practical effect is
that Reset Recovery (5.3.4) can't complete, which makes the terminal invalid-CBW state
from fix 1 escapable only via a bus reset.

Making it work needs a `control_out` on the `Transport` trait — defaulted, so it stays
non-breaking — plus `UsbClass::control_out` on `Scsi`/`Ufi` forwarding to it. Happy to
write that in whatever shape you prefer, or to leave it alone.

A couple of smaller things I looked at are genuine judgement calls rather than defects, so
they're not here and I won't push them.
