### PR TITLE
BBB: don't hand a command block to the subclass after an invalid CBW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- BBB: don't hand a command block to the subclass after an invalid CBW (https://github.com/apohrebniak/usbd-storage/pull/30)
+
 ## [3.0.0] - 2026-07-05
 
 ### Changed

--- a/usbd-storage/src/transport/bbb.rs
+++ b/usbd-storage/src/transport/bbb.rs
@@ -190,8 +190,16 @@ where
     }
 
     /// Returns a Command Block if present
+    ///
+    /// There is no command block while a CBW is still being received, and none
+    /// after an invalid one: per Spec. 6.6.1 an invalid CBW leaves the device
+    /// STALLing both pipes until a Reset Recovery, so `self.cbw` holds either
+    /// nothing at all or the previous command's block.
     pub fn get_command(&self) -> Option<CommandBlock<'_>> {
-        if matches!(self.state, State::CommandTransfer) {
+        if matches!(
+            self.state,
+            State::CommandTransfer | State::CommandTransferInvalid
+        ) {
             return None;
         }
 
@@ -954,6 +962,31 @@ mod tests {
         bbb.buf.write([0xFFu8; BUF_SIZE].as_slice()); // fill the buffer
 
         assert_eq!(N, bbb.read_data([0u8; N].as_mut_slice()).unwrap());
+    }
+
+    #[test]
+    fn invalid_cbw_yields_no_command_block() {
+        // Spec. 6.6.1: an invalid CBW is terminal until a Reset Recovery, so there
+        // is no command to hand to the subclass. Before this was guarded, a first
+        // CBW with a bad signature yielded a CommandBlock over an unpopulated
+        // CommandBlockWrapper -- an empty CDB, which panics subclass CDB parsers.
+        for ps in PACKET_SIZES {
+            let (shared, mut bbb) = new_bbb(ps);
+
+            let mut bad = cbw(0, Host::ExpectsNoData);
+            bad[0] ^= 0xFF; // corrupt dCBWSignature
+            enqueue(&shared, &bad, ps);
+
+            for _ in 0..64 {
+                let _ = bbb.poll();
+                if matches!(bbb.state, State::CommandTransferInvalid) {
+                    break;
+                }
+            }
+
+            assert_matches!(bbb.state, State::CommandTransferInvalid, "ps={ps}");
+            assert!(bbb.get_command().is_none(), "ps={ps}");
+        }
     }
 
     // ---- test harness ----

--- a/usbd-storage/tests/scsi_bbb.rs
+++ b/usbd-storage/tests/scsi_bbb.rs
@@ -13,6 +13,42 @@ use usbd_storage::transport::bbb::BulkOnly;
 
 const TIMEOUT: Duration = Duration::from_secs(1);
 
+/// A malformed CBW must not reach the subclass.
+///
+/// Spec. 6.6.1 makes an invalid CBW terminal until a Reset Recovery, so there is no
+/// command to dispatch. When `get_command` still reported one, the block came from an
+/// unpopulated `CommandBlockWrapper`; on the first CBW after power-up that is an empty
+/// CDB, and `scsi::parse_cb` indexes `cb[0]` -- an index-out-of-bounds panic in release
+/// builds, reachable from a single 31-byte packet on the wire.
+#[test]
+fn invalid_first_cbw_does_not_reach_the_subclass() {
+    let mut io_buf = [0u8; 1024];
+    let dummy_bus = DummyUsbBus::new();
+    let usb_bus = UsbBusAllocator::new(dummy_bus.clone());
+    let mut scsi = Scsi::new(&usb_bus, 64, 0, io_buf.as_mut_slice()).unwrap();
+    let _ = UsbDeviceBuilder::new(&usb_bus, UsbVidPid(0xabcd, 0xabcd)).build();
+
+    let mut bad = Cbw {
+        data_transfer_len: 0,
+        direction: DataDirection::NotExpected,
+        block: vec![0x12],
+    }
+    .into_bytes();
+    bad[0] ^= 0xFF; // corrupt dCBWSignature
+    dummy_bus.write_data(bad.as_slice());
+
+    scsi.poll(); // reads the CBW, enters the terminal invalid state
+
+    let mut dispatched = false;
+    scsi.poll_command(|_cmd| {
+        dispatched = true;
+        Ok(())
+    })
+    .unwrap();
+
+    assert!(!dispatched, "an invalid CBW was dispatched to the subclass");
+}
+
 #[test]
 fn should_fail_reading_data_from_host_with_bytes_processed() {
     run_on_scsi_bbb_bus_timed! { TIMEOUT, [


### PR DESCRIPTION
Split out of #28 as you asked — this is the invalid-CBW fix on its own, on top of `master`.

`get_command()` returns `Some` for every state except `CommandTransfer`, including the
terminal `CommandTransferInvalid`. Spec. 6.6.1 makes that state terminal until a Reset
Recovery, so there is no command to dispatch — but the subclass gets a `CommandBlock`
built over `self.cbw`, which at that point holds either the _previous_ command's block or,
on the first CBW after power-up, nothing at all.

Nothing at all means `block_len == 0`, i.e. an empty CDB, and `scsi::parse_cb` opens with
`match (cb[0], cb.len())`:

```
debug:   panicked at src/subclass/scsi.rs:131: assertion failed: !cb.is_empty()
release: panicked at src/subclass/scsi.rs:133: index out of bounds: the len is 0 but the index is 0
```

Reachable from a single 31-byte packet — a corrupted `dCBWSignature`, or a `bCBWCBLength`
outside 1..=16, as the first CBW after enumeration. Fix is to report no command in that
state.

## Testing

- `cargo test -p usbd-storage --all-features`, debug and release
- `cargo clippy -p usbd-storage --target thumbv7em-none-eabihf --all-features` and
  `--target thumbv6m-none-eabi`: clean
- `cargo fmt --check`: clean

New tests: `invalid_cbw_yields_no_command_block` (unit, transport level) and
`invalid_first_cbw_does_not_reach_the_subclass` (integration, through `Scsi`) — both fail
on `master`.

## Related

The other two thirds of #28 are #31 (the `dCBWDataTransferLength` cap) and #32
(the test-harness clippy warnings). They are independent, but #31 touches the same
`## [Unreleased]` block of `CHANGELOG.md`, so whichever lands second needs a one-line
rebase — say the word and I'll do it.

While I'm here, a related thing I flagged in #28 and did **not** fix, because every fix I
can think of adds public API: the Bulk-Only Mass Storage Reset can't currently be received.
Spec. 3.1 Table 3.1 gives it `bmRequestType` = `00100001b`, i.e. host-to-device, so
`usb-device` dispatches it to `UsbClass::control_out` — and the crate implements
`control_out` nowhere, so the `CLASS_SPECIFIC_BULK_ONLY_MASS_STORAGE_RESET` arm in
`control_in` never runs and `usb-device` rejects the request. The practical effect is that
Reset Recovery (5.3.4) can't complete, which makes the terminal state this PR guards
escapable only via a bus reset. Making it work needs a `control_out` on the `Transport`
trait — defaulted, so it stays non-breaking — plus `UsbClass::control_out` on `Scsi`/`Ufi`
forwarding to it. Happy to write that in whatever shape you prefer, or to leave it alone.
