### PR TITLE
BBB: never put more than dCBWDataTransferLength on the Bulk-In pipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- BBB: never put more than `dCBWDataTransferLength` bytes on the Bulk-In pipe (https://github.com/apohrebniak/usbd-storage/pull/31)
+
 ## [3.0.0] - 2026-07-05
 
 ### Changed

--- a/usbd-storage/src/transport/bbb.rs
+++ b/usbd-storage/src/transport/bbb.rs
@@ -404,7 +404,7 @@ where
 
         // allow a short packet if needed
         let bytes_sent = if self.left_to_transfer < self.packet_size() as u32 {
-            self.write_packet()?
+            self.write_packet(self.left_to_transfer as usize)?
         } else {
             self.try_write_full_packet()?
         };
@@ -424,7 +424,7 @@ where
             return self.handle_read_cbw();
         }
 
-        self.write_packet()?;
+        self.write_packet(CSW_LEN)?;
 
         Ok(())
     }
@@ -453,20 +453,14 @@ where
             return self.handle_status_transfer();
         }
 
+        // fill up to has_to_send if the subclass left us short
         let available = self.buf.available_read();
-
-        if available >= has_to_send {
-            // enough data to send a full packet
-            let bytes_written = self.write_packet()?;
-            self.mark_as_transferred(bytes_written as u32);
-        } else {
-            // fill up to has_to_send
-            let to_fill = has_to_send.saturating_sub(available);
-            self.buf.fill_up_to(FILL_BYTE, to_fill);
-
-            let bytes_written = self.write_packet()?;
-            self.mark_as_transferred(bytes_written as u32);
+        if available < has_to_send {
+            self.buf.fill_up_to(FILL_BYTE, has_to_send - available);
         }
+
+        let bytes_written = self.write_packet(has_to_send)?;
+        self.mark_as_transferred(bytes_written as u32);
 
         Ok(())
     }
@@ -599,13 +593,21 @@ where
 
     /// Tries to write a single packet into IN EP returning the number of bytes actually written
     ///
-    /// Might write a short packet if not enough data was in the buffer
-    fn write_packet(&mut self) -> BulkOnlyTransportResult<usize> {
-        let packet_size = self.packet_size();
+    /// Might write a short packet if not enough data was in the buffer.
+    ///
+    /// `max` caps how many bytes may go on the wire, on top of the packet size and
+    /// whatever the buffer holds. During a Data-In transfer that cap is the number of
+    /// bytes the host still expects, so a subclass that staged more than
+    /// `dCBWDataTransferLength` cannot make the device overrun the host's buffer
+    /// (Spec. 6.7.2: the device may send data up to a total of
+    /// `dCBWDataTransferLength`). Bytes staged beyond the cap are dropped when the
+    /// Status Transfer state cleans the buffer.
+    fn write_packet(&mut self, max: usize) -> BulkOnlyTransportResult<usize> {
+        let limit = min(self.packet_size(), max);
 
         let bytes_written = self.buf.read(|buf| {
             if !buf.is_empty() {
-                match self.in_ep.write(&buf[..min(packet_size, buf.len())]) {
+                match self.in_ep.write(&buf[..min(limit, buf.len())]) {
                     Ok(bytes_written) => {
                         trace!("usb: bbb: Wrote bytes: {}", bytes_written);
                         Ok(bytes_written)
@@ -631,7 +633,7 @@ where
             return Err(TransportError::Error(BulkOnlyError::FullPacketExpected));
         }
 
-        self.write_packet()
+        self.write_packet(self.packet_size())
     }
 }
 
@@ -954,6 +956,55 @@ mod tests {
         bbb.buf.write([0xFFu8; BUF_SIZE].as_slice()); // fill the buffer
 
         assert_eq!(N, bbb.read_data([0u8; N].as_mut_slice()).unwrap());
+    }
+
+    #[test]
+    fn short_data_in_request_is_not_overrun_by_try_write_data_all() {
+        // try_write_data_all applies no dCBWDataTransferLength cap -- it is meant for
+        // canned, fixed-size responses, which is how the examples answer INQUIRY,
+        // MODE SENSE and friends. When the host asks for fewer bytes than the canned
+        // response holds (ordinary host probing), the transport must still put only
+        // dCBWDataTransferLength bytes on the wire. Spec. 6.7.2.
+        const D: u32 = 4; // host asks for 4 bytes
+
+        for ps in PACKET_SIZES {
+            let (csw, data) = run(ps, D, Host::ExpectsDataIn, |b| {
+                b.try_write_data_all(&[0xAA; 36]).unwrap(); // canned INQUIRY response
+                b.set_status(CommandStatus::Passed, 36);
+            });
+            assert_eq!(data.len(), D as usize, "ps={ps}");
+            assert_eq!(csw.status, 0, "ps={ps}");
+            assert_eq!(csw.residue, 0, "ps={ps}");
+        }
+    }
+
+    #[test]
+    fn overstaged_data_in_is_truncated_to_the_requested_length() {
+        // write_data caps each call against left_to_transfer -- the UNSENT budget --
+        // so a subclass writing in several rounds can stage more than
+        // dCBWDataTransferLength in total. The wire must still carry no more than
+        // the host asked for.
+        const PS: u16 = 64;
+        const D: u32 = 100;
+
+        let (shared, mut bbb) = new_bbb(PS);
+        enqueue(&shared, &cbw(D, Host::ExpectsDataIn), PS);
+        let _ = bbb.poll(); // read CBW, enter DataTransferToHost
+
+        assert_eq!(100, bbb.write_data(&[0xAA; 100]).unwrap());
+        let _ = bbb.poll(); // sends one full packet; left_to_transfer 100 -> 36
+        assert_eq!(36, bbb.write_data(&[0xBB; 100]).unwrap()); // total staged: 136
+
+        bbb.set_status(CommandStatus::Passed, D);
+        for _ in 0..64 {
+            let _ = bbb.poll();
+            if matches!(bbb.state, State::CommandTransfer) {
+                break;
+            }
+        }
+
+        let stream = std::mem::take(&mut *shared.input.lock().unwrap()).concat();
+        assert_eq!(stream.len() - CSW_LEN, D as usize);
     }
 
     // ---- test harness ----


### PR DESCRIPTION
Split out of #28 as you asked — this is the `dCBWDataTransferLength` cap on its own, on top
of `master`. This is the one you said you'd look at properly, so it's now the only thing in
its PR.

Spec. 6.7.2 caps the Data-In phase: _"The device may send data up to a total of
dCBWDataTransferLength."_ Today it can exceed it, because nothing clamps the wire write:

- `write_packet()` writes `min(packet_size, buf.len())`, with no reference to
  `left_to_transfer`;
- `write_data()` caps each call against `left_to_transfer` — the _unsent_ budget rather
  than the _unwritten_ one — so a subclass writing in several rounds can stage more than
  `dCBWDataTransferLength` in total;
- `try_write_data_all()` applies no length cap at all.

That last one is the easy one to hit, because `try_write_data_all` is exactly what the
examples use for canned fixed-size responses. `rp2040_scsi_bbb.rs` answers INQUIRY with a
36-byte array; when a host asks for fewer bytes — ordinary probing, not an attack — the
device puts all 36 on the wire:

```
dCBWDataTransferLength = 4, handler writes 36 bytes  ->  36 bytes on the wire
```

Fix is a `max` argument on `write_packet`, passed as the number of bytes the host still
expects during a Data-In transfer and as `CSW_LEN` during the Status Transfer. Bytes staged
past the cap are dropped when the Status Transfer state cleans the buffer. This also makes
the `DataTransferToHostEnding` fill path honour `has_to_send`, which it previously computed
and then ignored; with both branches now identical apart from the fill, they collapse into
one.

I deliberately left `write_data`/`try_write_data_all` alone: changing what they accept
would change their contract, and clamping the wire is enough to keep the device inside the
spec. Happy to add a cap there too if you'd rather the staging APIs refuse the bytes up
front.

## Testing

- `cargo test -p usbd-storage --all-features`, debug and release
- `cargo clippy -p usbd-storage --target thumbv7em-none-eabihf --all-features` and
  `--target thumbv6m-none-eabi`: clean
- `cargo fmt --check`: clean

New tests: `short_data_in_request_is_not_overrun_by_try_write_data_all` and
`overstaged_data_in_is_truncated_to_the_requested_length` — both fail on `master`.

## Related

The other two thirds of #28 are #30 (the invalid-CBW guard) and #32 (the
test-harness clippy warnings). They are independent, but #30 touches the same
`## [Unreleased]` block of `CHANGELOG.md`, so whichever lands second needs a one-line
rebase — say the word and I'll do it.
