### PR TITLE
tests: clear the clippy warnings in the test harness

### DIFF
--- a/usbd-storage/src/transport/bbb.rs
+++ b/usbd-storage/src/transport/bbb.rs
@@ -776,7 +776,7 @@ mod tests {
     fn host_expects_no_data_device_sends_no_data() {
         // Case 1: Hn = Dn
         for ps in PACKET_SIZES {
-            let (csw, _) = run(ps, 0, Host::ExpectsNoData, |b| {
+            let (csw, _) = run(ps, 0, Host::NoData, |b| {
                 b.set_status(CommandStatus::Passed, 0)
             });
             assert_eq!(csw.status, 0, "ps={ps}");
@@ -788,7 +788,7 @@ mod tests {
     fn host_expects_no_data_device_wants_to_send() {
         // Case 2: Hn < Di -> Phase Error
         for ps in PACKET_SIZES {
-            let (csw, data) = run(ps, 0, Host::ExpectsNoData, |b| {
+            let (csw, data) = run(ps, 0, Host::NoData, |b| {
                 assert!(is_invalid_state(b.write_data(&[0xAA; 8])));
                 b.set_status(CommandStatus::PhaseError, 0);
             });
@@ -801,7 +801,7 @@ mod tests {
     fn host_expects_no_data_device_wants_to_receive() {
         // Case 3: Hn < Do -> Phase Error
         for ps in PACKET_SIZES {
-            let (csw, _) = run(ps, 0, Host::ExpectsNoData, |b| {
+            let (csw, _) = run(ps, 0, Host::NoData, |b| {
                 assert!(is_invalid_state(b.read_data(&mut [0u8; 8])));
                 b.set_status(CommandStatus::PhaseError, 0);
             });
@@ -815,7 +815,7 @@ mod tests {
     fn host_expects_data_in_device_sends_none() {
         // Case 4: Hi > Dn
         for ps in PACKET_SIZES {
-            let (csw, data) = run(ps, 32, Host::ExpectsDataIn, |b| {
+            let (csw, data) = run(ps, 32, Host::DataIn, |b| {
                 b.set_status(CommandStatus::Passed, 0)
             });
             assert_eq!(csw.status, 0, "ps={ps}");
@@ -828,7 +828,7 @@ mod tests {
     fn host_expects_more_data_in_than_device_sends() {
         // Case 5: Hi > Di
         for ps in PACKET_SIZES {
-            let (csw, data) = run(ps, 32, Host::ExpectsDataIn, |b| {
+            let (csw, data) = run(ps, 32, Host::DataIn, |b| {
                 let n = b.write_data(&[0xAA; 16]).unwrap();
                 b.set_status(CommandStatus::Passed, n as u32);
             });
@@ -842,7 +842,7 @@ mod tests {
     fn host_expects_exactly_what_device_sends() {
         // Case 6: Hi = Di
         for ps in PACKET_SIZES {
-            let (csw, data) = run(ps, 32, Host::ExpectsDataIn, |b| {
+            let (csw, data) = run(ps, 32, Host::DataIn, |b| {
                 let n = b.write_data(&[0xAA; 32]).unwrap();
                 b.set_status(CommandStatus::Passed, n as u32);
             });
@@ -856,7 +856,7 @@ mod tests {
     fn host_expects_less_data_in_than_device_sends() {
         // Case 7: Hi < Di -> Phase Error
         for ps in PACKET_SIZES {
-            let (csw, data) = run(ps, 16, Host::ExpectsDataIn, |b| {
+            let (csw, data) = run(ps, 16, Host::DataIn, |b| {
                 let n = b.write_data(&[0xAA; 32]).unwrap(); // capped to dCBWDataTransferLength
                 assert_eq!(n, 16); // device wanted to send more than the host allows
                 b.set_status(CommandStatus::PhaseError, 0);
@@ -870,7 +870,7 @@ mod tests {
     fn host_expects_data_in_device_wants_to_receive() {
         // Case 8: Hi <> Do -> Phase Error
         for ps in PACKET_SIZES {
-            let (csw, data) = run(ps, 32, Host::ExpectsDataIn, |b| {
+            let (csw, data) = run(ps, 32, Host::DataIn, |b| {
                 assert!(is_invalid_state(b.read_data(&mut [0u8; 32])));
                 b.set_status(CommandStatus::PhaseError, 0);
             });
@@ -885,7 +885,7 @@ mod tests {
     fn host_sends_data_device_receives_none() {
         // Case 9: Ho > Dn
         for ps in PACKET_SIZES {
-            let (csw, _) = run(ps, 32, Host::ExpectsDataOut, |b| {
+            let (csw, _) = run(ps, 32, Host::DataOut, |b| {
                 b.set_status(CommandStatus::Passed, 0)
             });
             assert_eq!(csw.status, 0, "ps={ps}");
@@ -897,7 +897,7 @@ mod tests {
     fn host_sends_data_device_wants_to_send() {
         // Case 10: Ho <> Di -> Phase Error
         for ps in PACKET_SIZES {
-            let (csw, _) = run(ps, 32, Host::ExpectsDataOut, |b| {
+            let (csw, _) = run(ps, 32, Host::DataOut, |b| {
                 assert!(is_invalid_state(b.write_data(&[0xAA; 8])));
                 b.set_status(CommandStatus::PhaseError, 0);
             });
@@ -909,7 +909,7 @@ mod tests {
     fn host_sends_more_data_out_than_device_receives() {
         // Case 11: Ho > Do
         for ps in PACKET_SIZES {
-            let (csw, _) = run(ps, 32, Host::ExpectsDataOut, |b| {
+            let (csw, _) = run(ps, 32, Host::DataOut, |b| {
                 let n = b.read_data(&mut [0u8; 16]).unwrap();
                 b.set_status(CommandStatus::Passed, n as u32);
             });
@@ -922,7 +922,7 @@ mod tests {
     fn host_sends_exactly_what_device_receives() {
         // Case 12: Ho = Do
         for ps in PACKET_SIZES {
-            let (csw, _) = run(ps, 32, Host::ExpectsDataOut, |b| {
+            let (csw, _) = run(ps, 32, Host::DataOut, |b| {
                 let n = b.read_data(&mut [0u8; 32]).unwrap();
                 b.set_status(CommandStatus::Passed, n as u32);
             });
@@ -935,7 +935,7 @@ mod tests {
     fn host_sends_less_data_out_than_device_receives() {
         // Case 13: Ho < Do -> Phase Error
         for ps in PACKET_SIZES {
-            let (csw, _) = run(ps, 16, Host::ExpectsDataOut, |b| {
+            let (csw, _) = run(ps, 16, Host::DataOut, |b| {
                 let n = b.read_data(&mut [0u8; 32]).unwrap(); // only what the host sent
                 assert_eq!(n, 16); // device wanted to receive more than the host sends
                 b.set_status(CommandStatus::PhaseError, 0);
@@ -960,11 +960,12 @@ mod tests {
 
     const PACKET_SIZES: [u16; 4] = [8, 16, 32, 64];
 
+    /// What the host expects: Spec. 6.7's Hn / Hi / Ho.
     #[derive(Copy, Clone)]
     enum Host {
-        ExpectsNoData,
-        ExpectsDataIn,  // device -> host
-        ExpectsDataOut, // host -> device
+        NoData,  // Hn
+        DataIn,  // Hi: device -> host
+        DataOut, // Ho: host -> device
     }
 
     /// Queues shared between the test and the bus moved into the allocator.
@@ -1041,7 +1042,7 @@ mod tests {
         c[..4].copy_from_slice(&0x43425355u32.to_le_bytes());
         c[4..8].copy_from_slice(&1u32.to_le_bytes()); // tag
         c[8..12].copy_from_slice(&data_len.to_le_bytes());
-        c[12] = if matches!(host, Host::ExpectsDataIn) {
+        c[12] = if matches!(host, Host::DataIn) {
             0x80
         } else {
             0x00
@@ -1074,7 +1075,7 @@ mod tests {
         let (shared, mut bbb) = new_bbb(packet_size);
 
         enqueue(&shared, &cbw(data_len, host), packet_size);
-        if matches!(host, Host::ExpectsDataOut) {
+        if matches!(host, Host::DataOut) {
             enqueue(&shared, &vec![0xAA; data_len as usize], packet_size);
         }
 
@@ -1082,7 +1083,7 @@ mod tests {
         // spans several packets at small MTUs, so this may take multiple polls.
         for _ in 0..64 {
             let _ = bbb.poll();
-            let out_drained = !matches!(host, Host::ExpectsDataOut) || bbb.left_to_transfer == 0;
+            let out_drained = !matches!(host, Host::DataOut) || bbb.left_to_transfer == 0;
             if bbb.get_command().is_some() && out_drained {
                 break;
             }

--- a/usbd-storage/tests/common/bbb.rs
+++ b/usbd-storage/tests/common/bbb.rs
@@ -289,10 +289,10 @@ impl UsbBus for DummyUsbBus {
             return Err(UsbError::InvalidEndpoint);
         }
 
-        if let Some(n) = ep.packets.front().map(|p| p.len()) {
-            if n > buf.len() {
-                return Err(UsbError::BufferOverflow);
-            }
+        if let Some(n) = ep.packets.front().map(|p| p.len())
+            && n > buf.len()
+        {
+            return Err(UsbError::BufferOverflow);
         }
 
         match ep.read_packet() {
@@ -308,32 +308,32 @@ impl UsbBus for DummyUsbBus {
     fn set_stalled(&self, ep_addr: EndpointAddress, stalled: bool) {
         let mut lock = self.inner.lock().unwrap();
 
-        if let Some(ep) = lock.ep_in.as_mut() {
-            if ep.addr == ep_addr {
-                return ep.stalled = stalled;
-            }
+        if let Some(ep) = lock.ep_in.as_mut()
+            && ep.addr == ep_addr
+        {
+            return ep.stalled = stalled;
         }
 
-        if let Some(ep) = lock.ep_out.as_mut() {
-            if ep.addr == ep_addr {
-                ep.stalled = stalled
-            }
+        if let Some(ep) = lock.ep_out.as_mut()
+            && ep.addr == ep_addr
+        {
+            ep.stalled = stalled
         }
     }
 
     fn is_stalled(&self, ep_addr: EndpointAddress) -> bool {
         let mut lock = self.inner.lock().unwrap();
 
-        if let Some(ep) = lock.ep_in.as_mut() {
-            if ep.addr == ep_addr {
-                return ep.stalled;
-            }
+        if let Some(ep) = lock.ep_in.as_mut()
+            && ep.addr == ep_addr
+        {
+            return ep.stalled;
         }
 
-        if let Some(ep) = lock.ep_out.as_mut() {
-            if ep.addr == ep_addr {
-                return ep.stalled;
-            }
+        if let Some(ep) = lock.ep_out.as_mut()
+            && ep.addr == ep_addr
+        {
+            return ep.stalled;
         }
 
         false


### PR DESCRIPTION
Split out of #28 as you asked — the clippy cleanup on its own, on top of `master`. No
behaviour change: everything here is inside `#[cfg(test)]` code.

`cargo clippy -p usbd-storage --all-features --all-targets` reports six warnings on
`master`:

- five `collapsible_if` in `usbd-storage/tests/common/bbb.rs` — applied with
  `cargo clippy --fix`;
- one `enum_variant_names` on the `Host` test enum in `src/transport/bbb.rs`, whose variants
  I shortened to `NoData` / `DataIn` / `DataOut` since the enum name already says "host". I
  added a doc line mapping them to Spec. 6.7's Hn / Hi / Ho while I was in there.

CI only lints the lib target (`cargo clippy -p usbd-storage --target … --all-features`), so
none of these fire in the pipeline today — this is only visible to someone running clippy
locally with `--all-targets`. Drop this PR without a second thought if you'd rather not
carry the rename.

## Note on CI

This one has no `CHANGELOG.md` entry, so the changelog enforcer will fail on it. A
test-harness cleanup isn't a user-visible change, so I'd rather not put it in the changelog
— the `skip-changelog` label should clear it. Tell me if you'd prefer an entry instead and
I'll add one.

## Testing

- `cargo test -p usbd-storage --all-features`, debug and release
- `cargo clippy -p usbd-storage --all-features --all-targets`: clean after this change
- `cargo fmt --check`: clean

## Related

The other two thirds of #28 are #30 (the invalid-CBW guard) and #31 (the
`dCBWDataTransferLength` cap). Both add tests that use the old `Host::Expects*` variant
names, so if this one lands first they'll need the rename applied — say the word and I'll
rebase whichever is left.
